### PR TITLE
save and load context for md5

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,20 @@ Synopsis
 
     local digest = md5:final()
 
+    -- save context for break uploading
+    local resty_md5 = require "resty.md5"
+    local str = require "resty.string"
+    local md5 = resty_md5:new()
+    ngx.say(md5:update("hel"))
+    md5:save_ctx("/tmp/test.ctx") 
+    
+    local nmd5 = resty_md5:new()
+    nmd5:load_ctx("/tmp/test.ctx")  -- load context and continue to update
+    ngx.say(nmd5:update("lo"))
+    local digest = nmd5:final()
+    ngx.say("md5: ", str.to_hex(digest))
+
+
     local str = require "resty.string"
     ngx.say("md5: ", str.to_hex(digest))
         -- yield "md5: 5d41402abc4b2a76b9719d911017c592"

--- a/lib/resty/md5.lua
+++ b/lib/resty/md5.lua
@@ -63,6 +63,54 @@ function reset(self)
     return C.MD5_Init(self._ctx) == 1
 end
 
+function save_ctx(self, fn)
+    local f,err = io.open(fn, "w")
+    if not f then 
+        return nil, err
+    end
+    
+    local ctx = {}
+    ctx.A   = self._ctx[0].A   
+    ctx.B   = self._ctx[0].B   
+    ctx.C   = self._ctx[0].C   
+    ctx.D   = self._ctx[0].D   
+    ctx.Nl  = self._ctx[0].Nl  
+    ctx.Nh  = self._ctx[0].Nh  
+    ctx.num = self._ctx[0].num 
+    ctx.data = {}
+    for i = 0,15 do
+        ctx.data[i+1] = self._ctx[0].data[i]
+    end
+
+    local cjson = require("cjson")
+    f:write(cjson.encode(ctx))
+    f:close()
+    return true
+end
+
+function load_ctx(self, fn)
+    local f,err = io.open(fn, "r")
+    if not f then 
+        return nil, err
+    end
+    local jstr = f:read()
+    f:close()
+
+    local cjson = require("cjson")
+    local ctx = cjson.decode(jstr)
+    self._ctx[0].A = ctx.A
+    self._ctx[0].B = ctx.B
+    self._ctx[0].C = ctx.C
+    self._ctx[0].D = ctx.D
+    self._ctx[0].Nl = ctx.Nl
+    self._ctx[0].Nh = ctx.Nh
+    self._ctx[0].num = ctx.num
+
+    for i = 0,15 do
+        self._ctx[0].data[i] = ctx.data[i+1]
+    end
+    return true
+end
 
 -- to prevent use of casual module global variables
 getmetatable(resty.md5).__newindex = function (table, key, val)

--- a/t/md5.t
+++ b/t/md5.t
@@ -90,3 +90,29 @@ md5: d41d8cd98f00b204e9800998ecf8427e
 --- no_error_log
 [error]
 
+=== TEST 4: MD5 save context
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local resty_md5 = require "resty.md5"
+            local str = require "resty.string"
+            local md5 = resty_md5:new()
+            ngx.say(md5:update("hel"))
+            md5:save_ctx("/tmp/test.ctx")
+
+            local nmd5 = resty_md5:new()
+            nmd5:load_ctx("/tmp/test.ctx")
+            ngx.say(nmd5:update("lo"))
+            local digest = nmd5:final()
+            ngx.say("md5: ", str.to_hex(digest))
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+md5: 5d41402abc4b2a76b9719d911017c592
+--- no_error_log
+[error]


### PR DESCRIPTION
In case of uploading breakdown, we won't to calculate md5 from begining.
So add the functions to continue md5_update().
