### PR TITLE
typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ Synopsis
 
     server {
         location = /test {
-            content_by_lua conf/test.lua;
+            content_by_lua_file conf/test.lua;
         }
     }
 


### PR DESCRIPTION
small typo in README, content_by_lua should be content_by_lua_file 
