### PR TITLE
Fix error on sample nginx config

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,7 @@ Synopsis
 ```lua
     # nginx.conf:
 
-    lua_package_path "/path/to/lua-resty-string/lib/?.lua;;"
+    lua_package_path "/path/to/lua-resty-string/lib/?.lua;;";
 
     server {
         location = /test {


### PR DESCRIPTION
Directive "lua_package_path" was not terminated by ";"
