### PR TITLE
add len parameter in update() of resty.md5

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,8 +81,8 @@ Synopsis
         ngx.say("failed to add data")
         return
     end
-
-    ok = md5:update("lo")
+        -- md5:update() with an optional "len" parameter
+    ok = md5:update("loxxx", 2)
     if not ok then
         ngx.say("failed to add data")
         return

--- a/lib/resty/md5.lua
+++ b/lib/resty/md5.lua
@@ -49,8 +49,8 @@ function _M.new(self)
 end
 
 
-function _M.update(self, s)
-    return C.MD5_Update(self._ctx, s, #s) == 1
+function _M.update(self, s, len)
+    return C.MD5_Update(self._ctx, s, len or #s) == 1
 end
 
 

--- a/t/md5.t
+++ b/t/md5.t
@@ -90,3 +90,36 @@ md5: d41d8cd98f00b204e9800998ecf8427e
 --- no_error_log
 [error]
 
+
+
+=== TEST 4: MD5 update with len parameter
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local resty_md5 = require "resty.md5"
+            local str = require "resty.string"
+            local md5 = resty_md5:new()
+            ngx.say(md5:update("hello", 3))
+            local digest = md5:final()
+            ngx.say(digest == ngx.md5_bin("hel"))
+            md5 = resty_md5:new()            
+            ngx.say(md5:update("hello", 3))
+            ngx.say(md5:update("loxxx", 2))
+            digest = md5:final()
+            ngx.say(digest == ngx.md5_bin("hello"))
+            ngx.say("md5: ", str.to_hex(digest))
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+true
+true
+true
+md5: 5d41402abc4b2a76b9719d911017c592
+--- no_error_log
+[error]
+


### PR DESCRIPTION
When I use  _M.update(self, s) in resty.md5, I had an case when len is not #s.
so, how about the following?

function _M.update(self, s, len)
    return C.MD5_Update(self._ctx, s, len or #s) == 1
end
