### PR TITLE
add function for padding setting

### DIFF
--- a/lib/resty/aes.lua
+++ b/lib/resty/aes.lua
@@ -180,13 +180,8 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds, padding)
         return nil
     end
 
-    if C.EVP_CIPHER_CTX_set_padding(encrypt_ctx, padding) == 0 then
-        return nil
-    end
-
-    if C.EVP_CIPHER_CTX_set_padding(decrypt_ctx, padding) == 0 then
-        return nil
-    end
+    C.EVP_CIPHER_CTX_set_padding(encrypt_ctx, padding)
+    C.EVP_CIPHER_CTX_set_padding(decrypt_ctx, padding)
 
     ffi_gc(encrypt_ctx, C.EVP_CIPHER_CTX_cleanup)
     ffi_gc(decrypt_ctx, C.EVP_CIPHER_CTX_cleanup)

--- a/lib/resty/aes.lua
+++ b/lib/resty/aes.lua
@@ -78,6 +78,8 @@ const EVP_CIPHER *EVP_aes_256_ofb(void);
 void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *a);
 int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *a);
 
+int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding);
+
 int EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx,const EVP_CIPHER *cipher,
         ENGINE *impl, unsigned char *key, const unsigned char *iv);
 
@@ -125,12 +127,13 @@ cipher = function (size, _cipher)
 end
 _M.cipher = cipher
 
-function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
+function _M.new(self, key, salt, _cipher, _hash, hash_rounds, padding)
     local encrypt_ctx = ffi_new(ctx_ptr_type)
     local decrypt_ctx = ffi_new(ctx_ptr_type)
     local _cipher = _cipher or cipher()
     local _hash = _hash or hash.md5
     local hash_rounds = hash_rounds or 1
+    local padding = padding or 1
     local _cipherLength = _cipher.size/8
     local gen_key = ffi_new("unsigned char[?]",_cipherLength)
     local gen_iv = ffi_new("unsigned char[?]",_cipherLength)
@@ -174,6 +177,14 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
       gen_key, gen_iv) == 0 or
       C.EVP_DecryptInit_ex(decrypt_ctx, _cipher.method, nil,
       gen_key, gen_iv) == 0 then
+        return nil
+    end
+
+    if C.EVP_CIPHER_CTX_set_padding(encrypt_ctx, padding) == 0 then
+        return nil
+    end
+
+    if C.EVP_CIPHER_CTX_set_padding(decrypt_ctx, padding) == 0 then
         return nil
     end
 

--- a/t/aes.t
+++ b/t/aes.t
@@ -308,9 +308,14 @@ failed to new: bad iv
             local aes = require "resty.aes"
             local str = require "resty.string"
             local key = ngx.decode_base64("abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=")
-            local aes_default = aes:new(key,nil,
-              aes.cipher(256,"cbc"),
-              {iv = string.sub(key,1,16)}, nil, 0)
+            local aes_default = aes:new(
+                key,
+                nil,
+                aes.cipher(256,"cbc"),
+                {iv = string.sub(key, 1, 16)}, 
+                nil, 
+                0
+            )
             local text = "hello"
             local block_size = 32
             local pad = block_size - #text % 32
@@ -334,5 +339,4 @@ pad: 27
 true
 --- no_error_log
 [error]
-
 

--- a/t/aes.t
+++ b/t/aes.t
@@ -298,3 +298,41 @@ failed to new: bad iv
 --- no_error_log
 [error]
 
+
+
+=== TEST 11: AES-256 CBC custom keygen, user padding  (without method)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local aes = require "resty.aes"
+            local str = require "resty.string"
+            local key = ngx.decode_base64("abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=")
+            local aes_default = aes:new(key,nil,
+              aes.cipher(256,"cbc"),
+              {iv = string.sub(key,1,16)}, nil, 0)
+            local text = "hello"
+            local block_size = 32
+            local pad = block_size - #text % 32
+            ngx.say("pad: ", pad)
+            text_paded = text .. string.rep(string.char(pad), pad)
+            local encrypted = aes_default:encrypt(text_paded)
+            ngx.say("AES-256 CBC (custom keygen, user padding with block_size=32) HEX: ", str.to_hex(encrypted))
+            local decrypted = aes_default:decrypt(encrypted)
+            local pad = string.byte(string.sub(decrypted, #decrypted))
+            ngx.say("pad: ", pad)
+            local decrypted_text = string.sub(decrypted, 1, #decrypted-pad)
+            ngx.say(decrypted_text == "hello")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+pad: 27
+AES-256 CBC (custom keygen, user padding with block_size=32) HEX: eebf8ca13072beede75c595a11b7fb0beffb7ccfb03f72d08456b555610172d1
+pad: 27
+true
+--- no_error_log
+[error]
+
+


### PR DESCRIPTION
add a function for padding:
int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding);
1>  padding = 0,  openssl not do auto padding;
2>  padding = 1,   openssl do auto padding;
default,  openssl do padding automaticaly.

because openssl do auto padding with block_size=16 for aes 256 cbc algorithm, some apps with other block_size for padding could not be encrypted or decrypted.

besides, openssl use pkcs7 format for auto padding, it also exist compatibility problem with other language, for example php, java, python, etc.

by adding this function, developer could select to cancel auto padding operation by openssl and do it byself.

you can referer this website about this function:
https://www.openssl.org/docs/manmaster/crypto/EVP_CIPHER_CTX_set_padding.html

3ks, 
Yanbo, Shu
