### PR TITLE
bug: fixed memory overrun bug when user provided a salt of less than 8

### DIFF
--- a/lib/resty/aes.lua
+++ b/lib/resty/aes.lua
@@ -159,6 +159,10 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
         ffi_copy(gen_iv, _hash.iv, 16)
 
     else
+        if salt and #salt ~= 8 then
+            return nil, "salt must be 8 characters or nil"
+        end
+
         if C.EVP_BytesToKey(_cipher.method, _hash, salt, key, #key,
                             hash_rounds, gen_key, gen_iv)
             ~= _cipherLength

--- a/t/aes.t
+++ b/t/aes.t
@@ -89,29 +89,24 @@ true
 
 
 
-=== TEST 4: AES oversized 10-byte salt
+=== TEST 4: AES oversized or too short salt
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
         content_by_lua '
             local aes = require "resty.aes"
             local str = require "resty.string"
-            local aes_default = aes:new("secret","Oversized!")
-            local encrypted = aes_default:encrypt("hello")
-            ngx.say("AES-128 (oversized salt) CBC MD5: ", str.to_hex(encrypted))
-            local decrypted = aes_default:decrypt(encrypted)
-            ngx.say(decrypted == "hello")
-            local aes_check = aes:new("secret","Oversize")
-            local encrypted_check = aes_check:encrypt("hello")
-            ngx.say(encrypted_check == encrypted)
+            local res, err = aes:new("secret","Oversized!")
+            ngx.say(res, ", ", err)
+            res, err = aes:new("secret","abc")
+            ngx.say(res, ", ", err)
         ';
     }
 --- request
 GET /t
 --- response_body
-AES-128 (oversized salt) CBC MD5: 90a9c9a96f06c597c8da99c37a6c689f
-true
-true
+nil, salt must be 8 characters or nil
+nil, salt must be 8 characters or nil
 --- no_error_log
 [error]
 


### PR DESCRIPTION
characters but EVP_BytesToKey() expects more. disallow salt string
longer than 8 characters to avoid false sense of security.

`EVP_BytesToKey()` expects `salt` to be either `NULL` or exactly 8 characters long. Too short it will run over memory pointed by `salt`, too long provides no added security or benefit. Therefore, making the length requirement explicit is probably not a bad idea.

**Ref:**
1. https://github.com/openssl/openssl/blob/master/crypto/evp/evp_key.c#L104
2. https://github.com/openssl/openssl/blob/c2bdf05f4b5430b5cc9d8122295b8484280e070f/include/openssl/evp.h#L23