### PR TITLE
use origin input key by default

### DIFF
--- a/lib/resty/aes.lua
+++ b/lib/resty/aes.lua
@@ -129,7 +129,6 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
     local encrypt_ctx = ffi_new(ctx_ptr_type)
     local decrypt_ctx = ffi_new(ctx_ptr_type)
     local _cipher = _cipher or cipher()
-    local _hash = _hash or hash.md5
     local hash_rounds = hash_rounds or 1
     local _cipherLength = _cipher.size/8
     local gen_key = ffi_new("unsigned char[?]",_cipherLength)
@@ -158,7 +157,7 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
 
         ffi_copy(gen_iv, _hash.iv, 16)
 
-    else
+    elseif _hash then
         if salt and #salt ~= 8 then
             return nil, "salt must be 8 characters or nil"
         end
@@ -169,6 +168,20 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
         then
             return nil
         end
+
+    else
+        -- use origin key by default
+        if not key then
+            return nil, "key is nil!"
+        end
+
+        if #key > _cipherLength then
+            return nil, "key too long"
+        end
+
+        -- note it's key padding not data padding, and it use zero padding only;
+        key = key..string.rep("\0", _cipherLength - #key)
+        ffi_copy(gen_key, key, _cipherLength)
     end
 
     C.EVP_CIPHER_CTX_init(encrypt_ctx)


### PR DESCRIPTION
this patch is mean to fix issues like #28, #19 
and it's now compatite with openssl shell command and php
**note** it's not related to pull request #35 : it's only about the key, not data.

**things might concern** : 
1. to compatite with former aes.lua version, one has to explicit write what hash method he/she need when using `new()` function, which is by default _M.hash.md5; 

eg:

> aes = require "resty.aes"
> aes:new("key", "salt", some_cipher, hash.md5, ....)

2. readme might need to update

