### PR TITLE
feature: support OpenSSL 1.1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,11 @@ env:
     - OPENSSL_PREFIX=/opt/ssl
     - OPENSSL_LIB=$OPENSSL_PREFIX/lib
     - OPENSSL_INC=$OPENSSL_PREFIX/include
-    - OPENSSL_VER=1.0.2h
     - LD_LIBRARY_PATH=$LUAJIT_LIB:$LD_LIBRARY_PATH
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.9.15
-    - NGINX_VERSION=1.11.2
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.0.2n
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0g
 
 install:
   - if [ ! -d download-cache ]; then mkdir download-cache; fi

--- a/lib/resty/aes.lua
+++ b/lib/resty/aes.lua
@@ -110,12 +110,13 @@ function _M.new(self, key, salt, _cipher, _hash, hash_rounds)
         return nil, "no memory"
     end
 
+    ffi_gc(encrypt_ctx, C.EVP_CIPHER_CTX_free)
+
     local decrypt_ctx = C.EVP_CIPHER_CTX_new()
     if decrypt_ctx == nil then
         return nil, "no memory"
     end
 
-    ffi_gc(encrypt_ctx, C.EVP_CIPHER_CTX_free)
     ffi_gc(decrypt_ctx, C.EVP_CIPHER_CTX_free)
 
     local _cipher = _cipher or cipher()


### PR DESCRIPTION
Replace `EVP_CIPHER_CTX_init` and `EVP_CIPHER_CTX_cleanup` with `EVP_CIPHER_CTX_new` and `EVP_CIPHER_CTX_free`, so that this library could work with both OpenSSL 1.0 and OpenSSL 1.1.