### PR TITLE
travis-ci: upgrade version numbers of nginx CORE and openssl, remove …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: c
 
 compiler:
   - gcc
-  - clang
 
 cache:
   directories:
@@ -28,9 +27,8 @@ env:
     - LD_LIBRARY_PATH=$LUAJIT_LIB:$LD_LIBRARY_PATH
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.19.3 OPENSSL_VER=1.0.2s
-    - NGINX_VERSION=1.19.3 OPENSSL_VER=1.1.0k
-    - NGINX_VERSION=1.19.3 OPENSSL_VER=1.1.1g
+    - NGINX_VERSION=1.19.9 OPENSSL_VER=1.1.0l
+    - NGINX_VERSION=1.19.9 OPENSSL_VER=1.1.1k
 
 install:
   - if [ ! -d download-cache ]; then mkdir download-cache; fi


### PR DESCRIPTION
…clang compiler mode and openssl 1.0.2 from travis.