### PR TITLE
tests: Certificate of Let's Encrypt expired, travis did not update the certificate in the image of trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 
 os: linux
 


### PR DESCRIPTION
https://app.travis-ci.com/github/openresty/lua-resty-string/jobs/542100635#L472