### PR TITLE
Make random.bytes cryptographically strong by default

### DIFF
--- a/lib/resty/random.lua
+++ b/lib/resty/random.lua
@@ -19,6 +19,7 @@ int RAND_pseudo_bytes(unsigned char *buf, int num);
 
 
 function _M.bytes(len, strong)
+    if strong == nil then strong = true end
     local buf = ffi_new("char[?]", len)
     if strong then
         if C.RAND_bytes(buf, len) == 0 then

--- a/lib/resty/random.lua
+++ b/lib/resty/random.lua
@@ -19,7 +19,9 @@ int RAND_pseudo_bytes(unsigned char *buf, int num);
 
 
 function _M.bytes(len, strong)
-    if strong == nil then strong = true end
+    if strong == nil then
+        strong = true
+    end
     local buf = ffi_new("char[?]", len)
     if strong then
         if C.RAND_bytes(buf, len) == 0 then


### PR DESCRIPTION
Non-cryptographic random bytes should be opt-in to help prevent misuse.